### PR TITLE
Fix for comments notification link & Compatibility with PHP 8.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "name": "On-Site-Notifications",
     "uri": "https://github.com/q2apro/q2apro-on-site-notifications",
     "description": "Facebook-like / Stackoverflow-like notifications on your question2answer forum that can replace all email-notifications.",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "date": "2018-08-23",
     "author": "q2apro.com",
     "author_uri": "http://www.question2answer.org/qa/user/q2apro",

--- a/q2apro-onsitenotifications-event.php
+++ b/q2apro-onsitenotifications-event.php
@@ -97,7 +97,7 @@
 					$paramstring='';
 
 					foreach ($params as $key => $value) {
-						$paramstring.=(strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);
+						$paramstring.=(strlen($paramstring ?? '') ? "\t" : '').$key.'='.$this->value_to_text($value);
 					}
 
 					// write in_ events to qa_eventlog
@@ -147,7 +147,7 @@
 					$paramstring='';
 
 					foreach ($params as $key => $value)
-						$paramstring.=(strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);
+						$paramstring.=(strlen($paramstring ?? '') ? "\t" : '').$key.'='.$this->value_to_text($value);
 
 					qa_db_query_sub(
 						'INSERT INTO ^eventlog (datetime, ipaddress, userid, handle, cookieid, event, params) '.
@@ -178,7 +178,7 @@
 
 							$paramstring = '';
 							foreach ($params as $key => $value) {
-								$paramstring .= (strlen($paramstring) ? "\t" : '').$key.'='.$this->value_to_text($value);
+								$paramstring .= (strlen($paramstring ?? '') ? "\t" : '').$key.'='.$this->value_to_text($value);
 							}
 
 							qa_db_query_sub(
@@ -198,7 +198,7 @@
 		function value_to_text($value) {
 			if (is_array($value))
 				$text='array('.count($value).')';
-			elseif (strlen($value)>40)
+			elseif (strlen($value ?? '')>40)
 				$text=substr($value, 0, 38).'...';
 			else
 				$text=$value;

--- a/q2apro-onsitenotifications-page.php
+++ b/q2apro-onsitenotifications-page.php
@@ -232,7 +232,7 @@
 								}
 
 								$anchor = qa_anchor((strpos($event['event'],'a_') === 0 || strpos($event['event'],'in_a_') === 0?'A':'C'), $params['postid']);
-								$activity_url = qa_path_absolute(qa_q_request($parent['postid'], $parent['title']), null, $anchor);
+								$activity_url = qa_q_path($parent['postid'], $parent['title'], true, strpos($event['event'],'in_a_') === 0?'A':'C', $params['postid']);
 								$linkTitle = $parent['title'];
 							}
 							else if(isset($post)) { // question

--- a/q2apro-onsitenotifications-page.php
+++ b/q2apro-onsitenotifications-page.php
@@ -123,7 +123,7 @@
 							$event['handle'] = qa_post_userid_to_handle($event['userid']);
 
 							// get message preview by cutting out the string
-							$event['message'] = substr($ustring,strpos($ustring,'message=')+8, strlen($ustring)-strpos($ustring,'message=')+8);
+							$event['message'] = substr($ustring,strpos($ustring,'message=')+8, strlen($ustring ?? '')-strpos($ustring,'message=')+8);
 
 							$events[$m[1].'_'.$count++] = $event;
 						}
@@ -143,7 +143,7 @@
 							$event['handle'] = qa_post_userid_to_handle($event['userid']);
 
 							// get message preview by cutting out the string
-							$event['message'] = substr($ustring,strpos($ustring,'text=')+5, strlen($ustring)-strpos($ustring,'text=')+5);
+							$event['message'] = substr($ustring,strpos($ustring,'text=')+5, strlen($ustring ?? '')-strpos($ustring,'text=')+5);
 
 							$events[$m[1].'_'.$count++] = $event;
 						}
@@ -426,9 +426,9 @@
 		{
 			$params = array();
 			// explode string to array with values (memo: leave "\t", '\t' will cause errors)
-			$paramsa = explode("\t", $event['params']);
+			$paramsa = explode("\t", $event['params'] ?? '');
 			foreach ($paramsa as $param) {
-				$parama = explode('=', $param);
+				$parama = explode('=', $param ?? '');
 				if (isset($parama[1])) {
 					$params[$parama[0]] = $parama[1];
 				} else {


### PR DESCRIPTION
- Fix for Comments notification link anchor.
  When there's too many comments and comments are collapsed, the anchoring for collapsed comments wasn't working properly.
  https://question2answer.org/qa/102932/

- Compatibility with PHP 8.1